### PR TITLE
perf: optimization work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,15 @@ documentation = "https://docs.rs/rev_lines"
 license = "MIT"
 authors = ["Michael Coyne <mjc@hey.com>"]
 keywords = ["lines", "reverse", "reader", "buffer", "iterator"]
+autobenches = false
 
 [dependencies]
 thiserror = "1.0.40"
+
+[dev-dependencies]
+iai = { git = "https://github.com/sigaloid/iai", rev = "6c83e942" }
+
+[[bench]]
+name = "iai"
+path = "benches/iai.rs"
+harness = false

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -1,0 +1,41 @@
+extern crate iai;
+extern crate rev_lines;
+
+use std::io::Cursor;
+
+use rev_lines::RawRevLines;
+
+const KB: usize = 1024;
+const FILE_LENGTH: usize = 20 * KB;
+
+fn input(file_length: usize, lines_length: u32) -> Vec<u8> {
+    let mut count = 0;
+    std::iter::from_fn(move || {
+        count += 1;
+
+        if count % lines_length == 0 {
+            Some(b'\n')
+        } else {
+            Some(b'a')
+        }
+    })
+    .take(file_length)
+    .collect()
+}
+
+fn raw_rev_lines_next_line_length_20_buffer_capacity_4096() {
+    let reader = Cursor::new(input(FILE_LENGTH, 20));
+    let mut rev_lines = RawRevLines::with_capacity(4096, reader);
+    while let Some(_) = rev_lines.next() {}
+}
+
+fn raw_rev_lines_next_line_length_160_buffer_capacity_4096() {
+    let reader = Cursor::new(input(FILE_LENGTH, 160));
+    let mut rev_lines = RawRevLines::with_capacity(4096, reader);
+    while let Some(_) = rev_lines.next() {}
+}
+
+iai::main!(
+    raw_rev_lines_next_line_length_20_buffer_capacity_4096,
+    raw_rev_lines_next_line_length_160_buffer_capacity_4096
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub struct RawRevLines<R> {
     reader: BufReader<R>,
     reader_pos: u64,
     buffer: Vec<u8>,
+    buffer_pos: usize,
 }
 
 impl<R: Seek + Read> RawRevLines<R> {
@@ -58,59 +59,54 @@ impl<R: Seek + Read> RawRevLines<R> {
             reader: BufReader::new(reader),
             reader_pos: u64::MAX,
             buffer: vec![0; cap],
+            buffer_pos: 0,
         }
     }
 
     fn init_reader(&mut self) -> io::Result<()> {
         // Seek to end of reader now
-        let reader_size = self.reader.seek(SeekFrom::End(0))?;
-        self.reader_pos = reader_size;
+        self.reader_pos = self.reader.seek(SeekFrom::End(0))?;
+
+        self.read_to_buffer()?;
 
         // Handle any trailing new line characters for the reader
         // so the first next call does not return Some("")
-
-        // Read at most 2 bytes
-        let end_size = min(reader_size, 2);
-        self.read_to_buffer(end_size)?;
-
-        if end_size == 1 {
-            if self.buffer[0] != LF_BYTE {
-                self.move_reader_position(1)?;
-            }
-        } else if end_size == 2 {
-            if self.buffer[0] != CR_BYTE {
-                self.move_reader_position(1)?;
-            }
-
-            if self.buffer[1] != LF_BYTE {
-                self.move_reader_position(1)?;
+        if self.buffer_pos > 0 {
+            if let Some(last_byte) = self.buffer.get(self.buffer_pos - 1) {
+                if *last_byte == LF_BYTE {
+                    self.buffer_pos -= 1;
+                    if self.buffer_pos > 0 {
+                        if let Some(second_to_last_byte) = self.buffer.get(self.buffer_pos - 1) {
+                            if *second_to_last_byte == CR_BYTE {
+                                self.buffer_pos -= 1;
+                            }
+                        }
+                    }
+                }
             }
         }
 
         Ok(())
     }
 
-    fn read_to_buffer(&mut self, size: u64) -> io::Result<()> {
+    fn read_to_buffer(&mut self) -> io::Result<()> {
+        let size = min(self.buffer.len() as u64, self.reader_pos);
         let offset = -(size as i64);
 
+        // TODO: we only need one seek
         self.reader.seek(SeekFrom::Current(offset))?;
         self.reader
             .read_exact(&mut self.buffer[0..(size as usize)])?;
         self.reader.seek(SeekFrom::Current(offset))?;
 
         self.reader_pos -= size;
-
-        Ok(())
-    }
-
-    fn move_reader_position(&mut self, offset: u64) -> io::Result<()> {
-        self.reader.seek(SeekFrom::Current(offset as i64))?;
-        self.reader_pos += offset;
+        self.buffer_pos = size as usize;
 
         Ok(())
     }
 
     fn next_line(&mut self) -> io::Result<Option<Vec<u8>>> {
+        // TODO: make self.reader_pos an Option, handle None in a helper method
         if self.reader_pos == u64::MAX {
             self.init_reader()?;
         }
@@ -118,32 +114,25 @@ impl<R: Seek + Read> RawRevLines<R> {
         let mut result: Vec<u8> = Vec::new();
 
         'outer: loop {
-            if self.reader_pos < 1 {
-                if !result.is_empty() {
-                    break;
-                }
-
-                return Ok(None);
+            // Current buffer was read to completion, read new contents
+            if self.buffer_pos == 0 {
+                // Read the of minimum between the desired
+                // buffer size or remaining length of the reader
+                self.read_to_buffer()?;
             }
 
-            // Read the of minimum between the desired
-            // buffer size or remaining length of the reader
-            let size = min(self.buffer.len() as u64, self.reader_pos);
+            if self.buffer_pos == 0 {
+                if result.is_empty() {
+                    return Ok(None);
+                } else {
+                    break;
+                }
+            }
 
-            self.read_to_buffer(size)?;
-            for (idx, ch) in self.buffer.iter().take(size as usize).enumerate().rev() {
+            for ch in self.buffer[..self.buffer_pos].iter().rev() {
+                self.buffer_pos -= 1;
                 // Found a new line character to break on
-                if *ch == LF_BYTE {
-                    let mut offset = idx as u64;
-
-                    // Add an extra byte cause of CR character
-                    if idx > 1 && self.buffer[idx - 1] == CR_BYTE {
-                        offset -= 1;
-                    }
-
-                    self.reader.seek(SeekFrom::Current(offset as i64))?;
-                    self.reader_pos += offset;
-
+                if *ch == LF_BYTE || *ch == CR_BYTE {
                     break 'outer;
                 } else {
                     result.push(*ch);
@@ -223,25 +212,31 @@ mod tests {
 
     #[test]
     fn raw_handles_file_with_one_line() -> TestResult {
-        let file = Cursor::new(b"ABCD\n".to_vec());
-        let mut rev_lines = RawRevLines::new(file);
+        let text = b"ABCD\n".to_vec();
+        for cap in 1..(text.len() + 1) {
+            let file = Cursor::new(&text);
+            let mut rev_lines = RawRevLines::with_capacity(cap, file);
 
-        assert_eq!(rev_lines.next().transpose()?, Some(b"ABCD".to_vec()));
-        assert_eq!(rev_lines.next().transpose()?, None);
+            assert_eq!(rev_lines.next().transpose()?, Some(b"ABCD".to_vec()));
+            assert_eq!(rev_lines.next().transpose()?, None);
+        }
 
         Ok(())
     }
 
     #[test]
     fn raw_handles_file_with_multi_lines() -> TestResult {
-        let file = Cursor::new(b"ABCDEF\nGHIJK\nLMNOPQRST\nUVWXYZ\n".to_vec());
-        let mut rev_lines = RawRevLines::new(file);
+        let text = b"ABCDEF\nGHIJK\nLMNOPQRST\nUVWXYZ\n".to_vec();
+        for cap in 1..(text.len() + 1) {
+            let file = Cursor::new(b"ABCDEF\nGHIJK\nLMNOPQRST\nUVWXYZ\n".to_vec());
+            let mut rev_lines = RawRevLines::with_capacity(cap, file);
 
-        assert_eq!(rev_lines.next().transpose()?, Some(b"UVWXYZ".to_vec()));
-        assert_eq!(rev_lines.next().transpose()?, Some(b"LMNOPQRST".to_vec()));
-        assert_eq!(rev_lines.next().transpose()?, Some(b"GHIJK".to_vec()));
-        assert_eq!(rev_lines.next().transpose()?, Some(b"ABCDEF".to_vec()));
-        assert_eq!(rev_lines.next().transpose()?, None);
+            assert_eq!(rev_lines.next().transpose()?, Some(b"UVWXYZ".to_vec()));
+            assert_eq!(rev_lines.next().transpose()?, Some(b"LMNOPQRST".to_vec()));
+            assert_eq!(rev_lines.next().transpose()?, Some(b"GHIJK".to_vec()));
+            assert_eq!(rev_lines.next().transpose()?, Some(b"ABCDEF".to_vec()));
+            assert_eq!(rev_lines.next().transpose()?, None);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
> One is about performance, I think there are some optimizations about how the vector returned from the iterator is constructed (instead of multiple pushes and a reverse, we can build the vector up from chunks). This would also require benchmarking to validate, so I'd add these as a bonus.

So this wasn't true in the end, trying anything fancy with chunks actually decreases performance and inserting elements in order (by using `VecDeque::push_front`) is not worth it for messing the API (by returning lesser known `VecDeque` instead of `Vec`).

However, the oldest trick in perf book, keeping the buffer around between iterations yielded 18-35% improvement, so there's that. I also added the benchmarks for future work.

This depends on and should be merged after https://github.com/mjc-gh/rev_lines/pull/13.