### PR TITLE
performance work vol. 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,14 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 iai = { git = "https://github.com/sigaloid/iai", rev = "6c83e942" }
+criterion = "0.5"
 
 [[bench]]
 name = "iai"
 path = "benches/iai.rs"
+harness = false
+
+[[bench]]
+name = "criterion"
+path = "benches/criterion.rs"
 harness = false

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,0 +1,49 @@
+extern crate criterion;
+use std::io::Cursor;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+extern crate rev_lines;
+use rev_lines::RawRevLines;
+
+fn input(file_length: usize, lines_length: u32) -> Vec<u8> {
+    let mut count = 0;
+    std::iter::from_fn(move || {
+        count += 1;
+
+        if count % lines_length == 0 {
+            Some(b'\n')
+        } else {
+            Some(b'a')
+        }
+    })
+    .take(file_length)
+    .collect()
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    for (file_length, line_length, buffer_capacity) in [
+        (1000000, 100, 20),
+        (1000000, 100, 50),
+        (1000000, 100, 100),
+        (1000000, 5, 4096),
+        (1000000, 20, 4096),
+        (1000000, 50, 4096),
+        (1000000, 80, 4096),
+        (1000000, 1000, 4096),
+    ] {
+        c.bench_function(
+            &format!("RawRevLines file_length={file_length} line_length={line_length}, buffer_capacity={buffer_capacity}"),
+            |b| {
+                b.iter(|| {
+                    let reader = Cursor::new(input(black_box(file_length), black_box(line_length)));
+                    let mut rev_lines = RawRevLines::with_capacity(buffer_capacity, reader);
+                    while let Some(_) = rev_lines.next() {}
+                })
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,10 @@ impl<R: Seek + Read> RawRevLines<R> {
         let offset = -(size as i64);
 
         // TODO: we only need one seek
-        self.reader.seek(SeekFrom::Current(offset))?;
+        self.reader.seek_relative(offset)?;
         self.reader
             .read_exact(&mut self.buffer[0..(size as usize)])?;
-        self.reader.seek(SeekFrom::Current(offset))?;
+        self.reader.seek_relative(offset)?;
 
         self.reader_pos -= size;
         self.buffer_pos = size as usize;


### PR DESCRIPTION
Includes:
* perf: use BufReader::seek_relative to actually make use of internal buffering
* perf: perform only one seek per read_to_buffer invocation
* refactor: make read_len a usize to minimize overflow risks
* perf: copy buffer subslices to result instead of pushing result per byte and reversing