### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rev_lines"
-version = "0.2.2"
+version = "0.3.0"
 description = "Rust Iterator for reading files line by line with a buffer in reverse"
 repository = "https://github.com/mikeycgto/rev_lines"
 documentation = "https://docs.rs/rev_lines"


### PR DESCRIPTION
To be merged after https://github.com/mjc-gh/rev_lines/pull/19 and https://github.com/mjc-gh/rev_lines/pull/20.